### PR TITLE
Added possibility to show overlays on page load + fix issue #6

### DIFF
--- a/js/jquery.galleryview-3.0-dev.js
+++ b/js/jquery.galleryview-3.0-dev.js
@@ -917,7 +917,7 @@ if (typeof Object.create !== 'function') {
 			this.$el = $(el);
 			this.id = el.id;
 			this.iterator = this.frameIterator = this.opts.start_frame - 1;
-			this.overlayVisible = false;
+			this.overlayVisible = this.opts.show_overlays;
 			this.playing = false;
 			this.scrolling = false;
 			this.isMouseDown = false;
@@ -980,7 +980,7 @@ if (typeof Object.create !== 'function') {
 			if(this.opts.enable_overlays) {
 				dom.gv_panelWrap.append(dom.gv_overlay,dom.gv_showOverlay);	
 			}
-			
+					
 			if(this.opts.show_captions) {
 				dom.gv_frame.append(dom.gv_caption).appendTo(dom.gv_gallery);	
 			}
@@ -1046,7 +1046,8 @@ if (typeof Object.create !== 'function') {
 		// Panel Options
 		show_panels: true, 				//BOOLEAN - flag to show or hide panel portion of gallery
 		show_panel_nav: true, 			//BOOLEAN - flag to show or hide panel navigation buttons
-		enable_overlays: false, 			//BOOLEAN - flag to show or hide panel overlays
+		enable_overlays: false, 		//BOOLEAN - flag to enable or disable panel overlays
+		show_overlays: false,			//BOOLEAN - flag to show or hide panel overlays on page load (if overlays are enabled) 
 		panel_width: 800, 				//INT - width of gallery panel (in pixels)
 		panel_height: 400, 				//INT - height of gallery panel (in pixels)
 		panel_animation: 'fade', 		//STRING - animation method for panel transitions (crossfade,fade,slide,none)

--- a/js/jquery.galleryview-3.0-dev.js
+++ b/js/jquery.galleryview-3.0-dev.js
@@ -621,7 +621,7 @@ if (typeof Object.create !== 'function') {
 			this.updateFilmstrip(frame_i);
 			this.showInfoBar();
 			
-			
+			document.getSelection().removeAllRanges(); // fixes selection of item
 		},
 		
 		updateOverlay: function(i) {


### PR DESCRIPTION
In this commit I added a setting to show overlays on page load. That way the overlay with info is expanded as soon as the page loads. I needed the function for my own website. Perhaps it's handy for others too.

Other commit fixes a bug in navigation in Firefox. See issue #6. The code deselects anything selected, so the image isn't highlighted. It'd be better to find out why the image is highlighted in the first place though.
