### PR TITLE
Fix for disappearing frame photos when user clicks current thumbnail

### DIFF
--- a/js/jquery.galleryview-3.0-dev.js
+++ b/js/jquery.galleryview-3.0-dev.js
@@ -568,6 +568,10 @@ if (typeof Object.create !== 'function') {
 					frame_i = dom.gv_panels.length - 1;
 				}
 			}
+
+			if( i == this.iterator ) {
+			  return;
+			}
 			
 			panel = dom.gv_panels.eq(i);
 			


### PR DESCRIPTION
Hi Jack:  great plugin!  I noticed a small glitch where the current photo will disappear if the user clicks the thumbnail for the current image.  The fix is for showItem to return without doing anything in this case.
