### PR TITLE
Wrong filmstrip size when show_filmstrip_nav is false

### DIFF
--- a/js/jquery.galleryview-3.0-dev.js
+++ b/js/jquery.galleryview-3.0-dev.js
@@ -185,6 +185,11 @@ if (typeof Object.create !== 'function') {
 				panels = [];
 			
 			// nav
+			if(!this.opts.show_filmstrip_nav){
+				widths.prev=0;
+				widths.next=0;
+				widths.play=0;
+			}
 			if(this.filmstripOrientation === 'horizontal') {
 				dom.gv_navWrap.css({
 					width: widths.prev + widths.play + widths.next,


### PR DESCRIPTION
Even if show_filmstrip_nav is false the size of navigation button is taken into account and the filmstrip is shorter than it should be.

We can easily fix this by resetting the length of navigation buttons when show_filmstrip_nav is false before calculating the length of filmstrip.
